### PR TITLE
[profile-site] Add light/dark/system theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,39 @@ import { LearningHistory } from "./components/LearningHistory";
 import { Other } from "./components/Other";
 import { Projects } from "./components/Projects";
 import { Skills } from "./components/Skills";
+import { ThemeToggle } from "./components/ThemeToggle";
 import { getLocale } from "./data/siteContent";
-import type { Locale } from "./types";
+import type { Locale, ResolvedTheme, ThemeMode } from "./types";
+
+const THEME_STORAGE_KEY = "theme_mode_v1";
+const prefersDarkQuery = "(prefers-color-scheme: dark)";
+
+const getStoredThemeMode = (): ThemeMode => {
+  if (typeof window === "undefined") {
+    return "system";
+  }
+
+  const storedValue = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (storedValue === "light" || storedValue === "dark" || storedValue === "system") {
+    return storedValue;
+  }
+
+  return "system";
+};
+
+const getSystemTheme = (): ResolvedTheme =>
+  window.matchMedia(prefersDarkQuery).matches ? "dark" : "light";
 
 function App() {
   const { i18n, t } = useTranslation();
   const [showIntro, setShowIntro] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => getStoredThemeMode());
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
+    typeof window === "undefined" ? "light" : getSystemTheme(),
+  );
   const locale: Locale = getLocale(i18n.language);
+  const resolvedTheme: ResolvedTheme = themeMode === "system" ? systemTheme : themeMode;
   const cvRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -35,12 +60,33 @@ function App() {
     document.documentElement.lang = locale;
   }, [locale]);
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(prefersDarkQuery);
+    const syncSystemTheme = () => {
+      setSystemTheme(mediaQuery.matches ? "dark" : "light");
+    };
+
+    syncSystemTheme();
+    mediaQuery.addEventListener("change", syncSystemTheme);
+    return () => {
+      mediaQuery.removeEventListener("change", syncSystemTheme);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.dataset.themeMode = themeMode;
+    document.documentElement.style.colorScheme = resolvedTheme;
+    window.localStorage.setItem(THEME_STORAGE_KEY, themeMode);
+  }, [resolvedTheme, themeMode]);
+
   const handleDownloadCv = async () => {
     if (!cvRef.current || isExporting) {
       return;
     }
 
     setIsExporting(true);
+    document.documentElement.dataset.exportingPdf = "true";
 
     try {
       const html2pdf = (await import("html2pdf.js")).default;
@@ -97,6 +143,7 @@ function App() {
         .from(cvRef.current)
         .save();
     } finally {
+      delete document.documentElement.dataset.exportingPdf;
       window.setTimeout(() => {
         setIsExporting(false);
       }, 150);
@@ -111,21 +158,24 @@ function App() {
           <a className="brand" href="#about">
             {t("brand")}
           </a>
-          <a
-            className="topGithubLink"
-            href="https://github.com/InryeolChoi"
-            target="_blank"
-            rel="noreferrer"
-            aria-label={t("github")}
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24">
-              <path
-                d="M12 1.5C6.201 1.5 1.5 6.201 1.5 12c0 4.64 3.01 8.577 7.188 9.967.525.098.712-.227.712-.504 0-.248-.009-.905-.014-1.777-2.924.636-3.541-1.409-3.541-1.409-.479-1.216-1.17-1.54-1.17-1.54-.956-.653.073-.64.073-.64 1.057.075 1.613 1.086 1.613 1.086.94 1.61 2.466 1.145 3.067.876.095-.68.368-1.145.67-1.409-2.334-.266-4.788-1.167-4.788-5.193 0-1.147.41-2.086 1.083-2.821-.109-.266-.469-1.337.103-2.788 0 0 .883-.283 2.896 1.078A10.08 10.08 0 0 1 12 6.614c.892.004 1.79.121 2.629.355 2.012-1.361 2.894-1.078 2.894-1.078.573 1.451.213 2.522.104 2.788.675.735 1.082 1.674 1.082 2.821 0 4.036-2.458 4.924-4.798 5.185.378.326.714.971.714 1.957 0 1.413-.013 2.552-.013 2.899 0 .279.186.607.719.503C19.493 20.573 22.5 16.638 22.5 12c0-5.799-4.701-10.5-10.5-10.5Z"
-                fill="currentColor"
-              />
-            </svg>
-            <span>{t("github")}</span>
-          </a>
+          <div className="topBarActions">
+            <ThemeToggle mode={themeMode} resolvedTheme={resolvedTheme} onChange={setThemeMode} />
+            <a
+              className="topGithubLink"
+              href="https://github.com/InryeolChoi"
+              target="_blank"
+              rel="noreferrer"
+              aria-label={t("github")}
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24">
+                <path
+                  d="M12 1.5C6.201 1.5 1.5 6.201 1.5 12c0 4.64 3.01 8.577 7.188 9.967.525.098.712-.227.712-.504 0-.248-.009-.905-.014-1.777-2.924.636-3.541-1.409-3.541-1.409-.479-1.216-1.17-1.54-1.17-1.54-.956-.653.073-.64.073-.64 1.057.075 1.613 1.086 1.613 1.086.94 1.61 2.466 1.145 3.067.876.095-.68.368-1.145.67-1.409-2.334-.266-4.788-1.167-4.788-5.193 0-1.147.41-2.086 1.083-2.821-.109-.266-.469-1.337.103-2.788 0 0 .883-.283 2.896 1.078A10.08 10.08 0 0 1 12 6.614c.892.004 1.79.121 2.629.355 2.012-1.361 2.894-1.078 2.894-1.078.573 1.451.213 2.522.104 2.788.675.735 1.082 1.674 1.082 2.821 0 4.036-2.458 4.924-4.798 5.185.378.326.714.971.714 1.957 0 1.413-.013 2.552-.013 2.899 0 .279.186.607.719.503C19.493 20.573 22.5 16.638 22.5 12c0-5.799-4.701-10.5-10.5-10.5Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>{t("github")}</span>
+            </a>
+          </div>
         </header>
 
         <main className={isExporting ? "pageContent exportMode" : "pageContent"} id="content" ref={cvRef}>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FiMonitor, FiMoon, FiSun } from "react-icons/fi";
+import { useTranslation } from "react-i18next";
+
+import type { ResolvedTheme, ThemeMode } from "../types";
+
+type ThemeToggleProps = {
+  mode: ThemeMode;
+  resolvedTheme: ResolvedTheme;
+  onChange: (mode: ThemeMode) => void;
+};
+
+const themeIconMap = {
+  light: FiSun,
+  dark: FiMoon,
+  system: FiMonitor,
+} as const;
+
+export function ThemeToggle({ mode, resolvedTheme, onChange }: ThemeToggleProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+    };
+  }, []);
+
+  const options = useMemo(
+    () => [
+      { mode: "light" as const, label: t("themeLight"), Icon: FiSun },
+      { mode: "dark" as const, label: t("themeDark"), Icon: FiMoon },
+      { mode: "system" as const, label: t("themeSystem"), Icon: FiMonitor },
+    ],
+    [t],
+  );
+  const TriggerIcon = themeIconMap[mode];
+
+  return (
+    <div className="themeToggleRoot" ref={rootRef}>
+      <button
+        type="button"
+        className={open ? "themeToggleButton isOpen" : "themeToggleButton"}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`${t("themeLabel")} (${t(`theme${mode[0].toUpperCase()}${mode.slice(1)}`)})`}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <TriggerIcon aria-hidden="true" />
+        <span className="themeToggleStatus">{resolvedTheme === "dark" ? t("themeDark") : t("themeLight")}</span>
+      </button>
+
+      <div className={open ? "themeToggleMenu isOpen" : "themeToggleMenu"} role="menu" aria-label={t("themeLabel")}>
+        {options.map(({ mode: optionMode, label, Icon }) => (
+          <button
+            key={optionMode}
+            type="button"
+            role="menuitemradio"
+            aria-checked={mode === optionMode}
+            className={mode === optionMode ? "themeToggleOption active" : "themeToggleOption"}
+            onClick={() => {
+              onChange(optionMode);
+              setOpen(false);
+            }}
+          >
+            <Icon aria-hidden="true" />
+            <span>{label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -47,6 +47,10 @@ const resources = {
       introTitle: "Loading profile",
       introSubtitle: "A quick look before the story begins",
       languageLabel: "Language",
+      themeLabel: "테마",
+      themeLight: "화이트",
+      themeDark: "다크",
+      themeSystem: "시스템",
     },
   },
   en: {
@@ -95,6 +99,10 @@ const resources = {
       introTitle: "Loading profile",
       introSubtitle: "A quick look before the story begins",
       languageLabel: "Language",
+      themeLabel: "Theme",
+      themeLight: "Light",
+      themeDark: "Dark",
+      themeSystem: "System",
     },
   },
 } as const;

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,83 @@
   --accent-soft: #dbeafe;
   --shadow-soft: 0 12px 32px rgba(15, 23, 42, 0.06);
   --shadow-strong: 0 24px 60px rgba(15, 23, 42, 0.08);
+  --page-bg: #ffffff;
+  --header-surface: rgba(255, 255, 255, 0.94);
+  --header-pill: rgba(248, 250, 252, 0.85);
+  --header-pill-hover: rgba(219, 234, 254, 0.7);
+  --floating-surface: rgba(248, 250, 252, 0.88);
+  --floating-surface-strong: rgba(248, 250, 252, 0.94);
+  --floating-border: rgba(148, 163, 184, 0.28);
+  --tooltip-surface: rgba(255, 255, 255, 0.94);
+  --tooltip-border: rgba(148, 163, 184, 0.18);
+  --interactive-surface: #ffffff;
+  --interactive-surface-hover: rgba(239, 246, 255, 0.72);
+  --skill-icon-surface: #1f2937;
+  --course-group-surface: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
+  --course-pill-border: rgba(226, 232, 240, 0.95);
+  --course-pill-shadow: 0 6px 16px rgba(15, 23, 42, 0.04);
+}
+
+:root[data-theme="dark"] {
+  color: #e5eefc;
+  background: #0b1220;
+  --ink-strong: #e5eefc;
+  --ink-soft: #9caecb;
+  --surface: #101826;
+  --surface-strong: #111b2b;
+  --surface-muted: #0d1522;
+  --line: rgba(148, 163, 184, 0.2);
+  --accent: #60a5fa;
+  --accent-deep: #93c5fd;
+  --accent-soft: rgba(96, 165, 250, 0.16);
+  --shadow-soft: 0 16px 40px rgba(2, 6, 23, 0.34);
+  --shadow-strong: 0 28px 72px rgba(2, 6, 23, 0.45);
+  --page-bg: radial-gradient(circle at top, rgba(30, 41, 59, 0.5), rgba(11, 18, 32, 1) 50%);
+  --header-surface: rgba(11, 18, 32, 0.84);
+  --header-pill: rgba(15, 23, 42, 0.86);
+  --header-pill-hover: rgba(37, 99, 235, 0.22);
+  --floating-surface: rgba(15, 23, 42, 0.9);
+  --floating-surface-strong: rgba(15, 23, 42, 0.96);
+  --floating-border: rgba(148, 163, 184, 0.2);
+  --tooltip-surface: rgba(15, 23, 42, 0.96);
+  --tooltip-border: rgba(148, 163, 184, 0.22);
+  --interactive-surface: #111b2b;
+  --interactive-surface-hover: rgba(37, 99, 235, 0.16);
+  --skill-icon-surface: #0f172a;
+  --course-group-surface: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(17, 27, 43, 0.98));
+  --course-pill-border: rgba(148, 163, 184, 0.22);
+  --course-pill-shadow: 0 10px 24px rgba(2, 6, 23, 0.3);
+}
+
+:root[data-exporting-pdf="true"] {
+  color: #14213d;
+  background: #ffffff;
+  --ink-strong: #111827;
+  --ink-soft: #475467;
+  --surface: #ffffff;
+  --surface-strong: #ffffff;
+  --surface-muted: #f8fafc;
+  --line: #e5e7eb;
+  --accent: #2563eb;
+  --accent-deep: #1d4ed8;
+  --accent-soft: #dbeafe;
+  --shadow-soft: 0 12px 32px rgba(15, 23, 42, 0.06);
+  --shadow-strong: 0 24px 60px rgba(15, 23, 42, 0.08);
+  --page-bg: #ffffff;
+  --header-surface: rgba(255, 255, 255, 0.94);
+  --header-pill: rgba(248, 250, 252, 0.85);
+  --header-pill-hover: rgba(219, 234, 254, 0.7);
+  --floating-surface: rgba(248, 250, 252, 0.88);
+  --floating-surface-strong: rgba(248, 250, 252, 0.94);
+  --floating-border: rgba(148, 163, 184, 0.28);
+  --tooltip-surface: rgba(255, 255, 255, 0.94);
+  --tooltip-border: rgba(148, 163, 184, 0.18);
+  --interactive-surface: #ffffff;
+  --interactive-surface-hover: rgba(239, 246, 255, 0.72);
+  --skill-icon-surface: #1f2937;
+  --course-group-surface: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
+  --course-pill-border: rgba(226, 232, 240, 0.95);
+  --course-pill-shadow: 0 6px 16px rgba(15, 23, 42, 0.04);
 }
 
 * {
@@ -34,7 +111,8 @@ body {
   min-width: 320px;
   min-height: 100vh;
   color: var(--ink-strong);
-  background: #ffffff;
+  background: var(--page-bg);
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 a {
@@ -68,8 +146,9 @@ img {
   align-items: center;
   justify-content: space-between;
   padding: 1.1rem clamp(1.2rem, 2vw, 2rem);
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--header-surface);
   border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(18px);
 }
 
 .brand {
@@ -79,6 +158,12 @@ img {
   letter-spacing: 0.05em;
 }
 
+.topBarActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
 .topGithubLink {
   display: inline-flex;
   align-items: center;
@@ -86,7 +171,7 @@ img {
   padding: 0.45rem 0.8rem;
   border-radius: 999px;
   border: 1px solid var(--line);
-  background: rgba(248, 250, 252, 0.85);
+  background: var(--header-pill);
   color: var(--ink-soft);
   transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
@@ -94,7 +179,94 @@ img {
 .topGithubLink:hover,
 .topGithubLink:focus-visible {
   transform: translateY(-1px);
-  background: rgba(219, 234, 254, 0.7);
+  background: var(--header-pill-hover);
+  color: var(--ink-strong);
+}
+
+.themeToggleRoot {
+  position: relative;
+}
+
+.themeToggleButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0 0.78rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--header-pill);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.themeToggleButton:hover,
+.themeToggleButton:focus-visible,
+.themeToggleButton.isOpen {
+  transform: translateY(-1px);
+  background: var(--header-pill-hover);
+  color: var(--ink-strong);
+}
+
+.themeToggleButton svg,
+.themeToggleOption svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.themeToggleStatus {
+  display: none;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.themeToggleMenu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.55rem);
+  z-index: 30;
+  display: grid;
+  gap: 0.35rem;
+  min-width: 10rem;
+  padding: 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow-soft);
+  opacity: 0;
+  transform: translateY(-8px);
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.themeToggleMenu.isOpen {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.themeToggleOption {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.55rem 0.75rem;
+  border: 0;
+  border-radius: 14px;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.themeToggleOption:hover,
+.themeToggleOption:focus-visible,
+.themeToggleOption.active {
+  background: var(--accent-soft);
   color: var(--ink-strong);
 }
 
@@ -127,9 +299,9 @@ img {
   justify-content: center;
   width: 3.3rem;
   height: 3.3rem;
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  border: 1px solid var(--floating-border);
   border-radius: 999px;
-  background: rgba(248, 250, 252, 0.88);
+  background: var(--floating-surface);
   backdrop-filter: blur(16px);
   box-shadow: 0 14px 34px rgba(15, 23, 42, 0.12);
   overflow: visible;
@@ -141,7 +313,7 @@ img {
 
 .floatingLanguageControl.isOpen {
   width: 7.2rem;
-  background: rgba(248, 250, 252, 0.94);
+  background: var(--floating-surface-strong);
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.14);
 }
 
@@ -151,9 +323,9 @@ img {
   bottom: calc(100% + 0.5rem);
   transform: translateX(50%);
   padding: 0.6rem 0.8rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--tooltip-border);
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--tooltip-surface);
   color: var(--ink-soft);
   box-shadow: 0 14px 34px rgba(15, 23, 42, 0.1);
   font-size: 0.84rem;
@@ -170,9 +342,9 @@ img {
   top: 100%;
   width: 10px;
   height: 10px;
-  background: rgba(255, 255, 255, 0.94);
-  border-right: 1px solid rgba(148, 163, 184, 0.18);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: var(--tooltip-surface);
+  border-right: 1px solid var(--tooltip-border);
+  border-bottom: 1px solid var(--tooltip-border);
   transform: translate(50%, -5px) rotate(45deg);
 }
 
@@ -210,13 +382,13 @@ img {
   border-radius: 999px;
   padding: 0;
   background: transparent;
-  color: rgba(71, 85, 105, 0.88);
+  color: var(--ink-soft);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .floatingLanguageOption.active {
-  background: rgba(191, 219, 254, 0.72);
+  background: var(--accent-soft);
   color: var(--ink-strong);
   font-weight: 700;
 }
@@ -239,7 +411,7 @@ img {
 .floatingLanguageTrigger:hover,
 .floatingLanguageTrigger:focus-visible {
   transform: scale(1.02);
-  background: rgba(239, 246, 255, 0.72);
+  background: var(--interactive-surface-hover);
   color: var(--ink-strong);
 }
 
@@ -247,7 +419,7 @@ img {
   opacity: 0;
   transform: scale(0.9);
   pointer-events: none;
-  background: rgba(219, 234, 254, 0.82);
+  background: var(--header-pill-hover);
   color: var(--ink-strong);
 }
 
@@ -382,7 +554,7 @@ img {
 
 .secondaryButton {
   border: 1px solid var(--line);
-  background: #ffffff;
+  background: var(--interactive-surface);
 }
 
 .primaryButton:hover,
@@ -420,7 +592,7 @@ img {
   width: min(100%, 360px);
   padding: 1rem;
   border-radius: 32px;
-  background: #ffffff;
+  background: var(--surface-strong);
   border: 1px solid var(--line);
   box-shadow: var(--shadow-strong);
   justify-self: end;
@@ -459,7 +631,7 @@ img {
 .wideCardHeader a {
   padding: 0.65rem 0.95rem;
   border: 1px solid var(--line);
-  background: #ffffff;
+  background: var(--interactive-surface);
   font-size: 0.92rem;
   font-weight: 700;
 }
@@ -501,7 +673,7 @@ img {
   padding: 1.5rem 1.6rem;
   border: 1px solid var(--line);
   border-radius: 28px;
-  background: #ffffff;
+  background: var(--surface);
   box-shadow: var(--shadow-soft);
 }
 
@@ -542,7 +714,7 @@ img {
   width: 64px;
   height: 64px;
   border-radius: 20px;
-  background: #1f2937;
+  background: var(--skill-icon-surface);
   color: #ffffff;
   font-size: 2rem;
 }
@@ -635,7 +807,7 @@ img {
   padding: 1rem 1.05rem;
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 20px;
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
+  background: var(--course-group-surface);
 }
 
 .courseGroupCard h4 {
@@ -660,10 +832,10 @@ img {
   gap: 0.5rem;
   padding: 0.5rem 0.7rem 0.5rem 0.8rem;
   border-radius: 999px;
-  background: #ffffff;
-  border: 1px solid rgba(226, 232, 240, 0.95);
+  background: var(--surface-strong);
+  border: 1px solid var(--course-pill-border);
   color: var(--ink-strong);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.04);
+  box-shadow: var(--course-pill-shadow);
   font-size: 0.92rem;
   line-height: 1.3;
 }
@@ -675,7 +847,7 @@ img {
   min-width: 2.3rem;
   padding: 0.2rem 0.45rem;
   border-radius: 999px;
-  background: rgba(219, 234, 254, 0.75);
+  background: var(--accent-soft);
   color: var(--accent-deep);
   font-size: 0.8rem;
   font-weight: 800;
@@ -781,7 +953,7 @@ img {
   padding: 0.75rem 0.9rem;
   border: 1px solid var(--line);
   border-radius: 14px;
-  background: #ffffff;
+  background: var(--surface-strong);
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
   color: var(--ink-soft);
   font-size: 0.92rem;
@@ -796,7 +968,7 @@ img {
   top: 100%;
   width: 10px;
   height: 10px;
-  background: #ffffff;
+  background: var(--surface-strong);
   border-right: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
   transform: translateY(-5px) rotate(45deg);
@@ -1087,6 +1259,11 @@ img {
 
   .topGithubLink {
     padding-inline: 0.7rem;
+  }
+
+  .themeToggleButton {
+    width: 2.5rem;
+    padding-inline: 0;
   }
 
   .topGithubLink span {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
 export type Locale = "ko" | "en";
+export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
 
 export type LinkItem = {
   label: string;


### PR DESCRIPTION
## Summary
- add a theme toggle button beside the GitHub action in the sticky header
- support light, dark, and system theme modes with local persistence
- update shared color variables so the site reacts to theme changes while keeping PDF export light

## Testing
- npm run build

Closes #1