### PR TITLE
[profile-site] Fix CV download button contrast in dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,9 @@
   --course-group-surface: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
   --course-pill-border: rgba(226, 232, 240, 0.95);
   --course-pill-shadow: 0 6px 16px rgba(15, 23, 42, 0.04);
+  --cv-button-bg: #111827;
+  --cv-button-border: #111827;
+  --cv-button-text: #ffffff;
 }
 
 :root[data-theme="dark"] {
@@ -65,6 +68,9 @@
   --course-group-surface: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(17, 27, 43, 0.98));
   --course-pill-border: rgba(148, 163, 184, 0.22);
   --course-pill-shadow: 0 10px 24px rgba(2, 6, 23, 0.3);
+  --cv-button-bg: #dbeafe;
+  --cv-button-border: rgba(147, 197, 253, 0.7);
+  --cv-button-text: #0b1220;
 }
 
 :root[data-exporting-pdf="true"] {
@@ -96,6 +102,9 @@
   --course-group-surface: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
   --course-pill-border: rgba(226, 232, 240, 0.95);
   --course-pill-shadow: 0 6px 16px rgba(15, 23, 42, 0.04);
+  --cv-button-bg: #111827;
+  --cv-button-border: #111827;
+  --cv-button-text: #ffffff;
 }
 
 * {
@@ -1082,13 +1091,13 @@ img {
 .cvButton {
   min-width: 220px;
   min-height: 50px;
-  border: 1px solid var(--ink-strong);
+  border: 1px solid var(--cv-button-border);
   border-radius: 999px;
-  background: var(--ink-strong);
-  color: #ffffff;
+  background: var(--cv-button-bg);
+  color: var(--cv-button-text);
   font-weight: 800;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, background-color 0.2s ease, color 0.2s ease;
   box-shadow: var(--shadow-soft);
 }
 


### PR DESCRIPTION
## Summary
- split the CV download button styling into dedicated theme variables
- keep the light-mode CTA appearance unchanged
- restore readable contrast in dark mode without affecting PDF export colors

## Testing
- npm run build

Closes #3