### PR TITLE
[codex] Tune dark mode CV download button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,8 @@
   --tooltip-border: rgba(148, 163, 184, 0.18);
   --interactive-surface: #ffffff;
   --interactive-surface-hover: rgba(239, 246, 255, 0.72);
+  --cv-button-bg: #111827;
+  --cv-button-text: #ffffff;
   --skill-icon-surface: #1f2937;
   --course-group-surface: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
   --course-pill-border: rgba(226, 232, 240, 0.95);
@@ -61,6 +63,8 @@
   --tooltip-border: rgba(148, 163, 184, 0.22);
   --interactive-surface: #111b2b;
   --interactive-surface-hover: rgba(37, 99, 235, 0.16);
+  --cv-button-bg: #1e3a5f;
+  --cv-button-text: #d8e1ee;
   --skill-icon-surface: #0f172a;
   --course-group-surface: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(17, 27, 43, 0.98));
   --course-pill-border: rgba(148, 163, 184, 0.22);
@@ -92,6 +96,8 @@
   --tooltip-border: rgba(148, 163, 184, 0.18);
   --interactive-surface: #ffffff;
   --interactive-surface-hover: rgba(239, 246, 255, 0.72);
+  --cv-button-bg: #111827;
+  --cv-button-text: #ffffff;
   --skill-icon-surface: #1f2937;
   --course-group-surface: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(255, 255, 255, 0.98));
   --course-pill-border: rgba(226, 232, 240, 0.95);
@@ -1082,10 +1088,10 @@ img {
 .cvButton {
   min-width: 220px;
   min-height: 50px;
-  border: 1px solid var(--ink-strong);
+  border: 1px solid var(--cv-button-bg);
   border-radius: 999px;
-  background: var(--ink-strong);
-  color: #ffffff;
+  background: var(--cv-button-bg);
+  color: var(--cv-button-text);
   font-weight: 800;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;


### PR DESCRIPTION
## Summary
Tune the CV PDF download button colors so the dark mode styling fits the rest of the page more naturally.

## What changed
- introduce button-specific CSS variables for the CV download button
- use a darker blue background in dark mode
- use a softer gray-white text color in dark mode
- keep light mode and PDF export colors unchanged

## Why
The previous blue and pure white combination felt too bright against the dark theme.

## Validation
- npm run build

Closes #7