### PR TITLE
[codex] Shorten language hint copy

### DIFF
--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -107,7 +107,7 @@ export function LanguageToggle({ locale, hidden = false }: LanguageToggleProps) 
       aria-label={t("languageLabel")}
     >
       <div className={open ? "floatingLanguageControl isOpen" : "floatingLanguageControl"}>
-        {showHint ? <div className="floatingLanguageHint">English version is here</div> : null}
+        {showHint ? <div className="floatingLanguageHint">language</div> : null}
         <button
           type="button"
           className={open ? "floatingLanguageTrigger isOpen" : "floatingLanguageTrigger"}


### PR DESCRIPTION
## Summary
- replace the floating language hint text with a shorter label
- keep the change scoped to the language toggle component only

## Why
The previous hint copy could still feel visually cramped on iPad-sized screens. Using a shorter label makes the hint more reliable and easier to read.

## Validation
- build passed in the original workspace after applying the same component change
- this branch contains only the copy update

Closes #11