### PR TITLE
[codex] Trigger Pages deploys from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow to trigger on pushes to main
- keep the workflow behavior unchanged aside from the branch trigger

## Why
The repository default branch is main, but the Pages workflow was still watching master. That meant merges into main did not trigger a new deployment, so the live site could lag behind the code in the repository.

## Validation
- confirmed the repository default branch is main
- confirmed the workflow trigger previously targeted master only
- verified the workflow file now targets main

## Impact
Merges into main will trigger the Pages deployment workflow again, so site updates should publish automatically.

Closes #14
