### PR TITLE
[codex] Sync iOS Safari theme color with theme mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#f8fafc" />
     <meta
       name="description"
       content="Inchoi's profile site with portfolio, projects, timeline, and experience."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,10 @@ import type { Locale, ResolvedTheme, ThemeMode } from "./types";
 
 const THEME_STORAGE_KEY = "theme_mode_v1";
 const prefersDarkQuery = "(prefers-color-scheme: dark)";
+const themeColorByTheme: Record<ResolvedTheme, string> = {
+  light: "#f8fafc",
+  dark: "#0b1220",
+};
 
 const getStoredThemeMode = (): ThemeMode => {
   if (typeof window === "undefined") {
@@ -77,6 +81,9 @@ function App() {
     document.documentElement.dataset.theme = resolvedTheme;
     document.documentElement.dataset.themeMode = themeMode;
     document.documentElement.style.colorScheme = resolvedTheme;
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", themeColorByTheme[resolvedTheme]);
     window.localStorage.setItem(THEME_STORAGE_KEY, themeMode);
   }, [resolvedTheme, themeMode]);
 


### PR DESCRIPTION
## Summary
- add a theme-color meta tag to the document head
- update the meta tag when the resolved site theme changes
- keep the change scoped to iOS Safari browser UI color sync

## Why
On iPhone and iPad Safari, the site content theme could switch to light while the browser UI still looked dark. Synchronizing theme-color with the resolved theme makes the browser chrome better match the selected theme.

## Validation
- build passed in the original workspace with the same changes applied
- verified the change is limited to index.html and src/App.tsx

Closes #17
