### PR TITLE
[codex] Fix CV PDF export layout and sync theme color

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#f8fafc" />
     <meta
       name="description"
       content="Inchoi's profile site with portfolio, projects, timeline, and experience."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,10 @@ import type { Locale, ResolvedTheme, ThemeMode } from "./types";
 
 const THEME_STORAGE_KEY = "theme_mode_v1";
 const prefersDarkQuery = "(prefers-color-scheme: dark)";
+const themeColorByTheme: Record<ResolvedTheme, string> = {
+  light: "#f8fafc",
+  dark: "#0b1220",
+};
 
 const getStoredThemeMode = (): ThemeMode => {
   if (typeof window === "undefined") {
@@ -77,6 +81,9 @@ function App() {
     document.documentElement.dataset.theme = resolvedTheme;
     document.documentElement.dataset.themeMode = themeMode;
     document.documentElement.style.colorScheme = resolvedTheme;
+    document
+      .querySelector('meta[name="theme-color"]')
+      ?.setAttribute("content", themeColorByTheme[resolvedTheme]);
     window.localStorage.setItem(THEME_STORAGE_KEY, themeMode);
   }, [resolvedTheme, themeMode]);
 

--- a/src/hooks/useViewportReveal.ts
+++ b/src/hooks/useViewportReveal.ts
@@ -48,6 +48,29 @@ export function getRevealMotion(isCompact: boolean, options: RevealOptions = {})
   const activeOffset = isCompact ? mobileOffset : offset;
   const initialPosition = axis === "x" ? { x: activeOffset } : { y: activeOffset };
   const settledPosition = axis === "x" ? { x: 0 } : { y: 0 };
+  const isExportingPdf =
+    typeof document !== "undefined" && document.documentElement.dataset.exportingPdf === "true";
+
+  if (isExportingPdf) {
+    return {
+      initial: {
+        ...settledPosition,
+        opacity: 1,
+      },
+      whileInView: {
+        ...settledPosition,
+        opacity: 1,
+      },
+      viewport: {
+        once: true,
+        amount: 0,
+      },
+      transition: {
+        duration: 0,
+        delay: 0,
+      },
+    };
+  }
 
   return {
     initial: {


### PR DESCRIPTION
## What changed
- fixed the CV PDF export so reveal-animated sections are forced into their final visible state during PDF generation
- synced the browser `theme-color` meta tag with the active light/dark theme mode

## Why
- downloading the CV PDF could produce a broken-looking result where sections appeared cut off or partially missing because viewport-based reveal animation state leaked into the export snapshot
- the browser chrome color should stay aligned with the current theme for a more consistent experience

## Root cause
- `html2pdf.js` captures the current DOM render state, and sections using viewport-based reveal motion could still be hidden or transitional when the PDF export started

## Validation
- `npm run build`

## Notes
- branch: `codex/update-pages-action-versions`
- related issue: Closes #19
